### PR TITLE
Automatically create code-defined roles if available

### DIFF
--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -178,6 +178,25 @@ class JWTCommonAuth:
 
         return validated_body
 
+    def get_role_definition(self, name: str) -> Optional[Model]:
+        """Simply get the RoleDefinition from the database if it exists and handler corner cases
+
+        If this is the name of a managed role for which we have a corresponding definition in code,
+        and that role can not be found in the database, it may be created here
+        """
+        from ansible_base.rbac.models import RoleDefinition
+
+        try:
+            return RoleDefinition.objects.get(name=name)
+        except RoleDefinition.DoesNotExist:
+            from ansible_base.rbac.permission_registry import permission_registry
+
+            constructor = permission_registry.get_managed_role_constructor_by_name(name)
+            if constructor:
+                rd, _ = constructor.get_or_create(apps)
+                return rd
+        return None
+
     def process_rbac_permissions(self):
         """
         This is a default process_permissions which should be usable if you are using RBAC from DAB
@@ -190,19 +209,17 @@ class JWTCommonAuth:
 
         for system_role_name in self.token.get("global_roles", []):
             logger.debug(f"Processing system role {system_role_name} for {self.user.username}")
-            try:
-                rd = RoleDefinition.objects.get(name=system_role_name)
+            rd = self.get_role_definition(system_role_name)
+            if rd:
                 rd.give_global_permission(self.user)
                 logger.info(f"Granted user {self.user.username} global role {system_role_name}")
-            except RoleDefinition.DoesNotExist:
+            else:
                 logger.error(f"Unable to grant {self.user.username} system level role {system_role_name} because it does not exist")
                 continue
 
         for object_role_name in self.token.get('object_roles', {}).keys():
-            rd = None
-            try:
-                rd = RoleDefinition.objects.get(name=object_role_name)
-            except RoleDefinition.DoesNotExist:
+            rd = self.get_role_definition(object_role_name)
+            if rd is None:
                 logger.error(f"Unable to grant {self.user.username} object role {object_role_name} because it does not exist")
                 continue
 

--- a/ansible_base/jwt_consumer/common/auth.py
+++ b/ansible_base/jwt_consumer/common/auth.py
@@ -201,8 +201,6 @@ class JWTCommonAuth:
         """
         This is a default process_permissions which should be usable if you are using RBAC from DAB
         """
-        from ansible_base.rbac.models import RoleDefinition
-
         if self.token is None or self.user is None:
             logger.error("Unable to process rbac permissions because user or token is not defined, please call authenticate first")
             return

--- a/ansible_base/rbac/models.py
+++ b/ansible_base/rbac/models.py
@@ -70,9 +70,9 @@ class ManagedRoleManager:
     def __getattr__(self, attr):
         if attr in self._cache:
             return self._cache[attr]
-        code_definition = permission_registry.get_managed_role_constructor(attr)
-        if code_definition:
-            rd, _ = code_definition.get_or_create(self.apps)
+        constructor = permission_registry.get_managed_role_constructor(attr)
+        if constructor:
+            rd, _ = constructor.get_or_create(self.apps)
             return rd
 
 

--- a/ansible_base/rbac/permission_registry.py
+++ b/ansible_base/rbac/permission_registry.py
@@ -111,8 +111,13 @@ class PermissionRegistry:
 
         return get_registry()
 
-    def get_managed_role_constructor(self, shortname):
+    def get_managed_role_constructor(self, shortname: str) -> Optional[ManagedRoleConstructor]:
         return self._managed_roles.get(shortname)
+
+    def get_managed_role_constructor_by_name(self, name: str) -> Optional[ManagedRoleConstructor]:
+        for managed_role in self._managed_roles.values():
+            if managed_role.name == name:
+                return managed_role
 
     def register_managed_role_constructor(self, shortname: str, managed_role: ManagedRoleConstructor) -> None:
         """Add the given managed role to the managed role registry"""


### PR DESCRIPTION
If a role is in the registry of "constructors" which contain the logic necessary to create a `managed=True` Role Definition, but it's not yet in the database, go ahead and create it.

The test got a little painful, but it _should_ have proper test isolation. I don't love the extra work needed to get there, but we got it.

The other alternative I considered was just to dynamically create the constructor registry from scratch whenever we need it. The problem there is that I want to allow users to manually register a full python class in code if they want, and this will only add the vendored constructors after apps are ready. But this might be something not truly worth supporting, I don't know.